### PR TITLE
re-enable deletion of coverage files in clean task

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -64,8 +64,6 @@ const config: HardhatUserConfig = {
   paths: {
     artifacts: "./artifacts",
     cache: "./cache",
-    coverage: "./coverage",
-    coverageJson: "./coverage.json",
     sources: "./contracts",
     tests: "./test",
   },

--- a/tasks/clean.ts
+++ b/tasks/clean.ts
@@ -3,8 +3,8 @@ import { TASK_CLEAN } from "hardhat/builtin-tasks/task-names";
 import { task } from "hardhat/config";
 
 task(TASK_CLEAN, "Overrides the standard clean task", async function (_taskArgs, { config }, runSuper) {
-  // await fsExtra.remove(config.paths.coverage);
-  // await fsExtra.remove(config.paths.coverageJson);
+  await fsExtra.remove("./coverage");
+  await fsExtra.remove("./coverage.json");
   if (config.typechain?.outDir) {
     await fsExtra.remove(config.typechain.outDir);
   }

--- a/types/augmentations.d.ts
+++ b/types/augmentations.d.ts
@@ -1,13 +1,6 @@
 import { Accounts, Signers } from "./";
 import { Greeter } from "../typechain/Greeter";
 
-declare module "hardhat/types" {
-  interface ProjectPathsUserConfig {
-    coverage: string;
-    coverageJson: string;
-  }
-}
-
 declare module "mocha" {
   export interface Context {
     accounts: Accounts;


### PR DESCRIPTION
The lines to clean up coverage files weren't uncommented in #6, this PR does so.

It also turns out that `solidity-coverage` doesn't allow us to specify the locations of the `coverage` directory and `coverage.json`. I've removed these from `hardhat.config.ts` as they're just a greater source of confusion than convenience in my opinion until `solidity-coverage` makes this configurable.