### PR TITLE
Update "Ethers": "^5.0.32" and "typescript": "^4.2.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.12.0",
     "ethereum-waffle": "^3.2.0",
-    "ethers": "^5.0.24",
+    "ethers": "^5.0.32",
     "fs-extra": "^9.0.1",
     "hardhat": "^2.0.10",
     "hardhat-typechain": "^0.3.5",
@@ -45,7 +45,7 @@
     "ts-generator": "^0.1.1",
     "ts-node": "^8.10.2",
     "typechain": "^4.0.1",
-    "typescript": "^3.9.7"
+    "typescript": "^4.2.2"
   },
   "files": [
     "/contracts"


### PR DESCRIPTION
# Problem
Ethers 5.0.24 has problem compiling typescript >= 3.8.3. When trying to compile with : `tsc -p tsconfig.js` it throw several compilation errors. Just for context, I'm built an API with solidity-template and I needed to compile the code to run in production.

# Solution
Ethers 5.0.32 bumped the typescript version to 4.2.2. https://github.com/ethers-io/ethers.js/issues/1288

This PR is updating both Ethers and Typescript.