### PR TITLE
fix: cleaning the generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "shx rm -rf ./artifacts ./cache ./coverage ./types ./coverage.json",
+    "clean": "shx rm -rf ./artifacts ./cache ./coverage ./src/types ./coverage.json",
     "commit": "git-cz",
     "compile": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat compile",
     "coverage": "yarn typechain && hardhat coverage --solcoverjs ./.solcover.js --temp artifacts --testfiles \"./test/**/*.ts\"",


### PR DESCRIPTION
before the command was trying to delete `./types` and now it deletes `./src/types`