### PR TITLE
feat: watch tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Run the Mocha tests:
 $ yarn test
 ```
 
+### Test with watch
+
+Watches for changes while running the tests:
+
+```sh
+$ yarn test:watch
+```
+
 ### Coverage
 
 Generate the code coverage report:

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,7 @@ import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import { config as dotenvConfig } from "dotenv";
 import "hardhat-gas-reporter";
+import "hardhat-watcher";
 import { HardhatUserConfig } from "hardhat/config";
 import { NetworkUserConfig } from "hardhat/types";
 import { resolve } from "path";
@@ -120,6 +121,16 @@ const config: HardhatUserConfig = {
   typechain: {
     outDir: "src/types",
     target: "ethers-v5",
+  },
+  watcher: {
+    test: {
+      files: ["./contracts", "./test"],
+      tasks: [
+        { command: "compile", params: { quiet: true } },
+        { command: "typechain", params: { quiet: true } },
+        { command: "test", params: { noCompile: true } },
+      ],
+    },
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fs-extra": "^10.0.1",
     "hardhat": "^2.9.2",
     "hardhat-gas-reporter": "^1.0.8",
+    "hardhat-watcher": "^2.1.1",
     "husky": "^7.0.4",
     "lint-staged": "^12.3.7",
     "lodash": "^4.17.21",
@@ -84,6 +85,7 @@
     "prettier": "prettier --config ./.prettierrc.yaml --write \"**/*.{js,json,md,sol,ts,yaml,yml}\"",
     "prettier:check": "prettier --check --config ./.prettierrc.yaml \"**/*.{js,json,md,sol,ts,yaml,yml}\"",
     "test": "hardhat test",
+    "test:watch": "hardhat watch test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,6 +2150,7 @@ __metadata:
     fs-extra: ^10.0.1
     hardhat: ^2.9.2
     hardhat-gas-reporter: ^1.0.8
+    hardhat-watcher: ^2.1.1
     husky: ^7.0.4
     lint-staged: ^12.3.7
     lodash: ^4.17.21
@@ -4856,7 +4857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:3.5.3":
+"chokidar@npm:3.5.3, chokidar@npm:^3.4.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -8673,6 +8674,17 @@ fsevents@~2.1.1:
   peerDependencies:
     hardhat: ^2.0.2
   checksum: bf18aacd08e0bdef81b180f3c97f76fcab885de3e92ed2dc014712e671c83ee7f77755c0e6c0f923a95f8372714cfcb7cdaa019afc42984c159603f8a8d724cf
+  languageName: node
+  linkType: hard
+
+"hardhat-watcher@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "hardhat-watcher@npm:2.1.1"
+  dependencies:
+    chokidar: ^3.4.3
+  peerDependencies:
+    hardhat: ^2.0.0
+  checksum: 1bd2e5b136c189260b9c38995e264eb76ee4b510abae79fe9193ced4817d01c5568eb1944bb9b83628448d927c689c3aa9aed6205ff7e6ad17aa6f14b77a2031
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Constantly running `yarn test` gets exhausting. 
This PR adds `hardhat-watcher` and a watch task `yarn test:watch` that recompiles the contracts and reruns the tests on change. 